### PR TITLE
validateXmlSvgRoot(): process % geometry

### DIFF
--- a/src/ofxSvgLoader.cpp
+++ b/src/ofxSvgLoader.cpp
@@ -150,7 +150,6 @@ void ofxSvgLoader::validateXmlSvgRoot( ofXml& aRootSvgNode ) {
 		if (restore_to_viewbox) {
 			ofXml::Attribute viewBoxAttr = aRootSvgNode.getAttribute("viewBox");
 			if( viewBoxAttr ) {
-				ofLogNotice("XXX") << ofStringEndsWith(wattr.getValue(),"%");
 				string tboxstr = viewBoxAttr.getValue();
 				vector<string> tvals = ofSplitString(tboxstr, " ");
 				

--- a/src/ofxSvgLoader.cpp
+++ b/src/ofxSvgLoader.cpp
@@ -112,48 +112,61 @@ string ofxSvgLoader::toString(int nlevel) {
     return tstr;
 }
 
+static bool ofStringEndsWith(const std::string &str, const std::string &suffix)
+{
+	return str.size() >= suffix.size() && 0 == str.compare(str.size() - suffix.size(), suffix.size(), suffix);
+}
+
 //--------------------------------------------------------------
 void ofxSvgLoader::validateXmlSvgRoot( ofXml& aRootSvgNode ) {
-    // if there is no width and height set in the svg base node, svg tiny no likey //
-    if(aRootSvgNode) {
-        // check for x, y, width and height //
-        {
-            auto xattr = aRootSvgNode.getAttribute("x");
-            if( !xattr ) {
-                auto nxattr = aRootSvgNode.appendAttribute("x");
-                if(nxattr) nxattr.set("0px");
-            }
-        }
-        {
-            auto yattr = aRootSvgNode.getAttribute("y");
-            if( !yattr ) {
-                auto yattr = aRootSvgNode.appendAttribute("y");
-                if( yattr ) yattr.set("0px");
-            }
-        }
-        
-        auto wattr = aRootSvgNode.getAttribute("width");
-        auto hattr = aRootSvgNode.getAttribute("height");
-        
-        if( !wattr || !hattr ) {
-            ofXml::Attribute viewBoxAttr = aRootSvgNode.getAttribute("viewBox");
-            if( viewBoxAttr ) {
-                string tboxstr = viewBoxAttr.getValue();
-                vector< string > tvals = ofSplitString( tboxstr, " " );
-                if( tvals.size() >= 4 ) {
-                    if( !wattr ) {
-                        auto nwattr = aRootSvgNode.appendAttribute("width");
-                        if(nwattr) nwattr.set( ofToString(tvals[2])+"px" );
-                    }
-                    
-                    if( !hattr ) {
-                        auto nhattr = aRootSvgNode.appendAttribute("height");
-                        if(nhattr) nhattr.set( ofToString(tvals[3])+"px" );
-                    }
-                }
-            }
-        }
-    }
+	// if there is no width and height set in the svg base node, svg tiny no likey //
+	if(aRootSvgNode) {
+		// check for x, y, width and height //
+		{
+			auto xattr = aRootSvgNode.getAttribute("x");
+			if( !xattr ) {
+				auto nxattr = aRootSvgNode.appendAttribute("x");
+				if(nxattr) nxattr.set("0px");
+			}
+		}
+		{
+			auto yattr = aRootSvgNode.getAttribute("y");
+			if( !yattr ) {
+				auto yattr = aRootSvgNode.appendAttribute("y");
+				if( yattr ) yattr.set("0px");
+			}
+		}
+		
+		auto wattr = aRootSvgNode.getAttribute("width");
+		auto hattr = aRootSvgNode.getAttribute("height");
+		
+		std::optional<glm::vec2> restore_to_viewbox;
+		if( !wattr || !hattr ) {
+			restore_to_viewbox = { 1.0f, 1.0f }; // missing width/height — apply viewbox at 100%
+		} else if (ofStringEndsWith(wattr.getValue(),"%") || ofStringEndsWith(wattr.getValue(),"%")) {
+			restore_to_viewbox = { wattr.getFloatValue()/100.0, hattr.getFloatValue()/100.0 };
+		}
+		
+		if (restore_to_viewbox) {
+			ofXml::Attribute viewBoxAttr = aRootSvgNode.getAttribute("viewBox");
+			if( viewBoxAttr ) {
+				ofLogNotice("XXX") << ofStringEndsWith(wattr.getValue(),"%");
+				string tboxstr = viewBoxAttr.getValue();
+				vector<string> tvals = ofSplitString(tboxstr, " ");
+				
+				if (tvals.size() >= 4) {
+					
+					if (!wattr) wattr = aRootSvgNode.appendAttribute("width");
+					if (wattr) wattr.set(ofToString(ofToFloat(tvals[2]) * restore_to_viewbox.value().x) + "px");
+					
+					if (!hattr) hattr = aRootSvgNode.appendAttribute("height");
+					if (hattr) hattr.set(ofToString(ofToFloat(tvals[3]) * restore_to_viewbox.value().y) + "px");
+				}
+			} else {
+				ofLogError("ofxSvgLoader::validateXmlSvgRoot") << "strangely-formed SVG without absolute width/height nor viewbox";
+			}
+		}
+	}
 }
 
 //--------------------------------------------------------------


### PR DESCRIPTION
Affinity designer exports "flattened" SVG like this:
```xml
<svg width="100%" height="100%" viewBox="0 0 1920 1080" 
version="1.1" xmlns="http://www.w3.org/2000/svg" 
xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve">
```
this % approach throws of svgtiny and it generates all vertices at (0, 0). SVGloader currently checks for existence of wattr/hattr, but not if they're numbers, and apparently svgtiny does not process %.

the proposed addition fixes this by checking if width and height are set to a %-value. if so, it replaces the width and height with the viewBox-corresponding proportional values. 

in other words, it should not be a breaking change as 
 - an SVG that has width/height defined as values with not be affected (as currently);
 - an SVG with no width-height will be set to 100% view box (as currently);
 - an SVG with % would not work.

It emits warning if a SVG has neither view box or absolute width/height.

[edit: whitespace got a bit nuked in the method; check with "hide whitespace" enabled]